### PR TITLE
Allow overriding the rego-cpp source location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,24 @@ cmake_minimum_required(VERSION 3.16)
 
 project(cheriot-policy LANGUAGES CXX)
 
+
+if (DEFINED ENV{REGOCPP_REPO})
+  set(REGOCPP_REPO $ENV{REGOCPP_REPO})
+else ()
+  set(REGOCPP_REPO "https://github.com/microsoft/rego-cpp/")
+endif ()
+
+if (DEFINED ENV{REGOCPP_TAG})
+  set(REGOCPP_TAG $ENV{REGOCPP_TAG})
+else ()
+  set(REGOCPP_TAG "cb967637dbf7cee25117203bbdf9c10b62dfb25a")
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   regocpp
-  GIT_REPOSITORY https://github.com/microsoft/rego-cpp.git
-  GIT_TAG        cb967637dbf7cee25117203bbdf9c10b62dfb25a
+  GIT_REPOSITORY ${REGOCPP_REPO}
+  GIT_TAG        ${REGOCPP_TAG}
 )
 FetchContent_MakeAvailable(regocpp)
 


### PR DESCRIPTION
This makes it easy for rego-cpp to use us for integration testing.