### PR TITLE
Updating to be compliant with rego-cpp v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif ()
 if (DEFINED ENV{REGOCPP_TAG})
   set(REGOCPP_TAG $ENV{REGOCPP_TAG})
 else ()
-  set(REGOCPP_TAG "v0.4.5")
+  set(REGOCPP_TAG "v1.0.1")
 endif()
 
 include(FetchContent)

--- a/compartment.hh
+++ b/compartment.hh
@@ -6,24 +6,24 @@ namespace
 	auto compartmentPackage = R"(
 		package compartment
 
-		compartment_contains_export(compartment, export) {
+		compartment_contains_export(compartment, export) if {
 			compartment.exports[_] == export
 		}
 
-		compartment_includes_file(compartment, filename) {
+		compartment_includes_file(compartment, filename) if {
 			compartment.code.inputs[_].file == filename
 		}
 
-		compartment_includes_file(compartment, filename) {
+		compartment_includes_file(compartment, filename) if {
 			compartment.data.inputs[_].file == filename
 		}
 
-		export_matches_import(export, importEntry)  {
+		export_matches_import(export, importEntry) if  {
 			export.export_symbol = importEntry.export_symbol
 		}
 
 
-		export_for_import(importEntry) = entry { 
+		export_for_import(importEntry) = entry if { 
 			some possibleEntries
 			some allExports
 			allExports = {export | input.compartments[_].exports[_] = export}
@@ -33,31 +33,31 @@ namespace
 			entry := possibleEntries[0].entry
 		}
 
-		import_is_library_call(a) { a.kind = "LibraryFunction" }
-		import_is_MMIO(a) { a.kind = "MMIO" }
-		import_is_compartment_call(a) {
+		import_is_library_call(a) if { a.kind = "LibraryFunction" }
+		import_is_MMIO(a) if { a.kind = "MMIO" }
+		import_is_compartment_call(a) if {
 			a.kind = "CompartmentExport"
 			a.function
 		}
 
-		import_is_call {
+		import_is_call if {
 			import_is_library_call(importEntry)
 		}
 
-		import_is_call {
+		import_is_call if {
 			import_is_compartment_call(importEntry)
 		}
 
-		mmio_imports_for_compartment(compartment) = entry {
+		mmio_imports_for_compartment(compartment) = entry if {
 			entry := [e | e = compartment.imports[_]; import_is_MMIO(e)]
 		}
 
-		mmio_is_device(importEntry, device) {
+		mmio_is_device(importEntry, device) if {
 			importEntry.start = device.start
 			importEntry.length = device.length
 		}
 
-		device_for_mmio_import(importEntry) = device {
+		device_for_mmio_import(importEntry) = device if {
 			import_is_MMIO(importEntry)
 			some devices
 			devices = [{ i:d } | d = data.board.devices[i]; mmio_is_device(importEntry, d)]
@@ -65,50 +65,50 @@ namespace
 			device := devices[0]
 		}
 
-		compartment_imports_device(compartment, device) {
+		compartment_imports_device(compartment, device) if {
 			count([d | d = mmio_imports_for_compartment(compartment)[_] ; mmio_is_device(d, device)]) > 0
 		}
 
-		compartments_with_mmio_import(device) = compartments {
+		compartments_with_mmio_import(device) = compartments if {
 			compartments = [i | c = input.compartments[i]; compartment_imports_device(c, device)]
 		}
 
-		shared_object_imports_for_compartment(compartment) = entry {
+		shared_object_imports_for_compartment(compartment) = entry if {
 			entry := [e | e = compartment.imports[_]; e.kind = "SharedObject"]
 		}
 
-		compartment_imports_shared_object(compartment, object) {
-			count([d | d = shared_object_imports_for_compartment(compartment)[_] ; d.shared_object = object)]) > 0
+		compartment_imports_shared_object(compartment, object) if {
+			count([d | d = shared_object_imports_for_compartment(compartment)[_] ; d.shared_object = object]) > 0
 		}
 
-		compartment_imports_shared_object_writeable(compartment, object) {
+		compartment_imports_shared_object_writeable(compartment, object) if {
 			count([d | d = shared_object_imports_for_compartment(compartment)[_] ; d.shared_object = object
 			d.permits_store = true]) > 0
 		}
 
-		compartments_with_shared_object_import(object) = compartments {
+		compartments_with_shared_object_import(object) = compartments if {
 			compartments = [i | c = input.compartments[i]; compartment_imports_shared_object(c, object)]
 		}
 
-		compartments_with_shared_object_import_writeable(object) = compartments {
+		compartments_with_shared_object_import_writeable(object) = compartments if {
 			compartments = [i | c = input.compartments[i]; compartment_imports_shared_object_writeable(c, object)]
 		}
 
 
-		compartment_export_matching_symbol(compartmentName, symbol) = export {
+		compartment_export_matching_symbol(compartmentName, symbol) = export if {
 			some compartment
 			compartment = input.compartments[compartmentName]
 			some exports
-			exports = [e | e = compartment.exports[_]; re_match(symbol, export_entry_demangle(compartmentName, e.export_symbol))]
+			exports = [e | e = compartment.exports[_]; regex.match(symbol, export_entry_demangle(compartmentName, e.export_symbol))]
 			count(exports) == 1
 			export := exports[0]
 		}
 
-		compartments_calling_export(export) = compartments {
+		compartments_calling_export(export) = compartments if {
 			compartments = [c | i = input.compartments[c].imports[_]; export_matches_import(i, export)]
 		}
 
-		compartments_calling_export_matching(compartmentName, export) = compartments {
+		compartments_calling_export_matching(compartmentName, export) = compartments if {
 			compartments = compartments_calling_export(compartment_export_matching_symbol(compartmentName, export))
 		}
 
@@ -117,7 +117,7 @@ namespace
 		# this every evaluation.
 		#entry_point_map := { entry.export_symbol : compartment | entry = input.compartments[compartment].exports[_] ; entry.kind = "Function"}
 
-		compartment_exports_function(callee, importEntry) {
+		compartment_exports_function(callee, importEntry) if {
 			#entry_point_map[importEntry.export_symbol] == callee
 			some possibleEntries
 			possibleEntries = [entry | entry = input.compartments[callee].exports[_]; export_matches_import(entry, importEntry)]
@@ -126,11 +126,11 @@ namespace
 		}
 
 		# Helper to work around rego-cpp#117
-		check_export(exports, importEntry, compartment) {
+		check_export(exports, importEntry, compartment) if {
 			exports[importEntry.export_symbol] == compartment
 		}
 
-		compartments_calling(callee) = compartments {
+		compartments_calling(callee) = compartments if {
 			# Create a reverse map that maps from exported symbols to
 			# compartments.  This avoids some O(n^2) lookups.  It would be nice
 			# to cache this globally but rego-cpp doesn't support that yet.
@@ -146,34 +146,34 @@ namespace
 		# accepts an array of compartment names that match some property and
 		# evaluates to true if and only if each one is also present in the allow
 		# list.
-		allow_list(testArray, allowList) {
+		allow_list(testArray, allowList) if {
 			some compartments
 			compartments = {c | c:=testArray[_]}
 			compartments & allowList == compartments
 		}
 
-		mmio_allow_list(mmioName, allowList) {
+		mmio_allow_list(mmioName, allowList) if {
 			allow_list(compartments_with_mmio_import(data.board.devices[mmioName]), allowList)
 		}
 
-		shared_object_allow_list(objectName, allowList) {
+		shared_object_allow_list(objectName, allowList) if {
 			allow_list(compartments_with_shared_object_import(objectName), allowList)
 		}
 
-		shared_object_writeable_allow_list(objectName, allowList) {
+		shared_object_writeable_allow_list(objectName, allowList) if {
 			allow_list(compartments_with_shared_object_import_writeable(objectName), allowList)
 		}
 
 
-		compartment_call_allow_list(compartmentName, exportPattern, allowList) {
+		compartment_call_allow_list(compartmentName, exportPattern, allowList) if {
 			allow_list(compartments_calling_export_matching(compartmentName, exportPattern), allowList)
 		}
 
-		compartment_allow_list(compartmentName, allowList) {
+		compartment_allow_list(compartmentName, allowList) if {
 			allow_list(compartments_calling(compartmentName), allowList)
 		}
 
-		shared_object(name) = object {
+		shared_object(name) = object if {
 			some imports
 			imports = [ i | i = input.sharedObjects[_] ; i.name = name]
 			count(imports) == 1

--- a/rtos.hh
+++ b/rtos.hh
@@ -6,21 +6,19 @@ namespace
 	auto rtosPackage = R"(
 		package rtos
 		
-		import future.keywords
-
-		is_allocator_capability(capability) {
+		is_allocator_capability(capability) if {
 			capability.kind == "SealedObject"
 			capability.sealing_type.compartment == "allocator"
 			capability.sealing_type.key == "MallocKey"
 		}
 
-		is_allocator_capability(capability) {
+		is_allocator_capability(capability) if {
 			capability.kind == "SealedObject"
 			capability.sealing_type.compartment == "alloc"
 			capability.sealing_type.key == "MallocKey"
 		}
 
-		decode_allocator_capability(capability) = decoded {
+		decode_allocator_capability(capability) = decoded if {
 			is_allocator_capability(capability)
 			some quota
 			quota = integer_from_hex_string(capability.contents, 0, 4)
@@ -33,7 +31,7 @@ namespace
 			decoded := { "quota": quota }
 		}
 
-		all_sealed_allocator_capabilities_are_valid {
+		all_sealed_allocator_capabilities_are_valid if {
 			some allocatorCapabilities
 			allocatorCapabilities = [ c | c = input.compartments[_].imports[_] ; is_allocator_capability(c) ]
 			every c in allocatorCapabilities {
@@ -42,7 +40,7 @@ namespace
 		}
 
 		# Check that the allocator imports the hazard list with the correct permissions.
-		allocator_hazard_list_permissions_are_valid {
+		allocator_hazard_list_permissions_are_valid if {
 			some hazardListImport
 			hazardListImport = [ i | i = input.compartments.allocator.imports[_] ; i.shared_object == "allocator_hazard_pointers"]
 			every i in hazardListImport {
@@ -53,7 +51,7 @@ namespace
 			}
 		}
 
-		valid {
+		valid if {
 			all_sealed_allocator_capabilities_are_valid
 			# Only the allocator may access the revoker.
 			data.compartment.mmio_allow_list("revoker", {"allocator"})


### PR DESCRIPTION
The rego-cpp v1.0.0 release broke a few things in the public API, and also updated the Rego language support to v1.8.0. This has broken the cheriot integration. This PR makes changes to the policies and the audit code to use the new API and be compliant with Rego v1.8.0.